### PR TITLE
feat: ユーザ作成アプリケーションサービスを実装

### DIFF
--- a/application/user/index.go
+++ b/application/user/index.go
@@ -1,0 +1,63 @@
+package user
+
+import (
+	"errors"
+
+	repository "github.com/karamaru-alpha/ddd-sample/domain/repository/user"
+	domainService "github.com/karamaru-alpha/ddd-sample/domain/service/user"
+	valueObject "github.com/karamaru-alpha/ddd-sample/domain/value_object/user"
+	factory "github.com/karamaru-alpha/ddd-sample/factory/user"
+)
+
+// IApplicationService Interface of ApplicationService realize usecase
+type IApplicationService interface {
+	Register(name string, mailAdress string) error
+}
+
+type applicationService struct {
+	domainService domainService.IDomainService
+	repository    repository.IRepository
+	factory       factory.IFactory
+}
+
+// NewApplicationService Function create user ApplicationService
+func NewApplicationService(
+	userDomainService domainService.IDomainService,
+	userRepository repository.IRepository,
+	userFactory factory.IFactory,
+) IApplicationService {
+	return &applicationService{
+		domainService: userDomainService,
+		repository:    userRepository,
+		factory:       userFactory,
+	}
+}
+
+// Register ApplicationService realize account registration
+func (as applicationService) Register(name string, mailAdress string) error {
+
+	userName, err := valueObject.NewName(name)
+	if err != nil {
+		return err
+	}
+
+	userMailAdress, err := valueObject.NewMailAdress(mailAdress)
+	if err != nil {
+		return err
+	}
+
+	user, err := as.factory.Create(userName, userMailAdress)
+	if err != nil {
+		return err
+	}
+
+	isDup, err := as.domainService.Exists(user)
+	if err != nil {
+		return err
+	}
+	if isDup {
+		return errors.New("This user already exists")
+	}
+
+	return as.repository.Save(user)
+}

--- a/domain/entity/user/index.go
+++ b/domain/entity/user/index.go
@@ -3,34 +3,33 @@ package user
 import (
 	"errors"
 
-	"github.com/google/uuid"
 	valueObject "github.com/karamaru-alpha/ddd-sample/domain/value_object/user"
 )
 
-// User Entity express user.
+// User Entity express user
 type User struct {
 	ID         valueObject.ID
 	Name       valueObject.Name
 	MailAdress valueObject.MailAdress
 }
 
-// NewUser Constructor generate user entity.
-func NewUser(id valueObject.ID, name valueObject.Name, mailAdress valueObject.MailAdress) (*User, error) {
+// NewUser Constructor generate user entity
+func NewUser(id *valueObject.ID, name *valueObject.Name, mailAdress *valueObject.MailAdress) (*User, error) {
 
-	if id == valueObject.ID(uuid.Nil) {
+	if id == nil {
 		return nil, errors.New("UserID is null")
 	}
-	if name == "" {
+	if name == nil {
 		return nil, errors.New("UserName is null")
 	}
-	if mailAdress == "" {
+	if mailAdress == nil {
 		return nil, errors.New("UserMailAdress is null")
 	}
 
 	user := new(User)
-	user.ID = id
-	user.Name = name
-	user.MailAdress = mailAdress
+	user.ID = *id
+	user.Name = *name
+	user.MailAdress = *mailAdress
 
 	return user, nil
 }

--- a/domain/repository/user/index.go
+++ b/domain/repository/user/index.go
@@ -5,7 +5,8 @@ import (
 	valueObject "github.com/karamaru-alpha/ddd-sample/domain/value_object/user"
 )
 
-// IRepository Repository perpetuate/rebuild user entity.
+// IRepository Interface of Repository perpetuate/rebuild user entity
 type IRepository interface {
-	Find(valueObject.MailAdress) (*entity.User, error)
+	Save(*entity.User) error
+	Find(*valueObject.MailAdress) (*entity.User, error)
 }

--- a/domain/service/user/index.go
+++ b/domain/service/user/index.go
@@ -2,29 +2,29 @@ package user
 
 import (
 	entity "github.com/karamaru-alpha/ddd-sample/domain/entity/user"
-	ur "github.com/karamaru-alpha/ddd-sample/domain/repository/user"
+	repository "github.com/karamaru-alpha/ddd-sample/domain/repository/user"
 )
 
-// DomainService DomainService interface express domain activity.
-type DomainService interface {
+// IDomainService Inteface of DomainService express domain activity
+type IDomainService interface {
 	Exists(user *entity.User) (bool, error)
 }
 
 type domainService struct {
-	repository ur.IRepository
+	repository repository.IRepository
 }
 
-// NewDomainService create DomainService
-func NewDomainService(userRepository ur.IRepository) DomainService {
+// NewDomainService Function create DomainService
+func NewDomainService(userRepository repository.IRepository) IDomainService {
 	return &domainService{
 		repository: userRepository,
 	}
 }
 
-// Exists DomainService check user duplicate.
+// Exists DomainService check user duplicate
 func (ds domainService) Exists(user *entity.User) (bool, error) {
 
-	dupUser, err := ds.repository.Find(user.MailAdress)
+	dupUser, err := ds.repository.Find(&user.MailAdress)
 	if err != nil {
 		return false, err
 	}

--- a/domain/value_object/user/id.go
+++ b/domain/value_object/user/id.go
@@ -6,10 +6,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// ID Value object express user's ID.
+// ID Value object express user's ID
 type ID uuid.UUID
 
-// NewID Constructor generate user's ID value object.
+// NewID Constructor generate user's ID value object
 func NewID(arg uuid.UUID) (*ID, error) {
 
 	if arg == uuid.Nil {

--- a/domain/value_object/user/mali_adress.go
+++ b/domain/value_object/user/mali_adress.go
@@ -4,10 +4,10 @@ import (
 	"errors"
 )
 
-// MailAdress Value object express user's mail adress.
+// MailAdress Value object express user's mail adress
 type MailAdress string
 
-// NewMailAdress Constructor generate user's MailAdress value object.
+// NewMailAdress Constructor generate user's MailAdress value object
 func NewMailAdress(arg string) (*MailAdress, error) {
 
 	if arg == "" {

--- a/domain/value_object/user/name.go
+++ b/domain/value_object/user/name.go
@@ -5,10 +5,10 @@ import (
 	"unicode/utf8"
 )
 
-// Name Value object express user's name.
+// Name Value object express user's name
 type Name string
 
-// NewName Constructor generate user's Name value object.
+// NewName Constructor generate user's Name value object
 func NewName(arg string) (*Name, error) {
 
 	if arg == "" {

--- a/factory/user/index.go
+++ b/factory/user/index.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"github.com/google/uuid"
+
+	entity "github.com/karamaru-alpha/ddd-sample/domain/entity/user"
+	valueObject "github.com/karamaru-alpha/ddd-sample/domain/value_object/user"
+)
+
+// IFactory Interface of Factory help to generate Object.
+type IFactory interface {
+	Create(name *valueObject.Name, mailAdress *valueObject.MailAdress) (*entity.User, error)
+}
+
+type factory struct{}
+
+// NewFactory create UserFactory.
+func NewFactory() IFactory {
+	return &factory{}
+}
+
+// Create Factory help to generate UserEntity.
+func (factory) Create(name *valueObject.Name, mailAdress *valueObject.MailAdress) (*entity.User, error) {
+
+	generatedUUID, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
+	}
+
+	userID, err := valueObject.NewID(generatedUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := entity.NewUser(userID, name, mailAdress)
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}


### PR DESCRIPTION
## About
ユーザ作成アプリケーションサービスを実装しました。
## Details
- fix: 引数・帰り値をポインタ渡しにする
- feat: repositoryにUser永続化を行う`Save`メソッドを実装する
- feat: Userオブジェクトの作成をラップする`Factory`を実装。IDの採番などの煩雑な処理を経てEntityを返却することが責務
- feat: アカウント登録のユースケースを実現する`AppkicationService`を実装
## Remarks
- 具体的なDB接続や依存性の注入・エラーハンドリングは後述
- Dockerで組み立てるつもり
## Preview
```
$ tree ./
```

<img width="280" alt="スクリーンショット 2021-02-20 16 25 28" src="https://user-images.githubusercontent.com/38310693/108587653-3ff24f80-7398-11eb-8d7a-15262e6eefd7.png">

