### PR TITLE
refactor: UserID値オブジェクトをstringに

### DIFF
--- a/domain/value_object/user/id.go
+++ b/domain/value_object/user/id.go
@@ -2,18 +2,15 @@ package user
 
 import (
 	"errors"
-
-	"github.com/oklog/ulid"
 )
 
 // ID Value object express user's ID
-type ID ulid.ULID
+type ID string
 
 // NewID Constructor generate user's ID value object
-func NewID(arg ulid.ULID) (*ID, error) {
-	var zeroValueULID ulid.ULID
+func NewID(arg string) (*ID, error) {
 
-	if arg.Compare(zeroValueULID) == 0 {
+	if arg == "" {
 		return nil, errors.New("UserID is null")
 	}
 

--- a/factory/user/index.go
+++ b/factory/user/index.go
@@ -40,8 +40,9 @@ func (factory) Create(name *valueObject.Name, mailAddress *valueObject.MailAddre
 	return user, nil
 }
 
-func generateULID() ulid.ULID {
+// generateULID Function generate ULID string
+func generateULID() string {
 	t := time.Now()
 	entropy := ulid.Monotonic(rand.New(rand.NewSource(t.UnixNano())), 0)
-	return ulid.MustNew(ulid.Timestamp(t), entropy)
+	return ulid.MustNew(ulid.Timestamp(t), entropy).String()
 }


### PR DESCRIPTION
# About
DBに入れる時とかにstringの方が取り回し簡単そうだと思ったのでPRにした。

けど、これだとどんな文字列もUserIDに入ってしまい、不正代入を防ぐ効能が減るから一旦reject.