### PR TITLE
feat: ユーザ登録時にパスワードも登録する

### DIFF
--- a/application/user/create_command.go
+++ b/application/user/create_command.go
@@ -2,6 +2,7 @@ package user
 
 // CreateCommand Command object about user creation
 type CreateCommand struct {
-	Name        string
-	MailAddress string
+	Name          string
+	MailAddress   string
+	PlainPassword string
 }

--- a/application/user/service.go
+++ b/application/user/service.go
@@ -44,7 +44,12 @@ func (as applicationService) Register(createCommand CreateCommand) error {
 		return err
 	}
 
-	user, err := as.factory.Create(userName, userMailAddress)
+	userPlainPassword, err := domainModel.NewPlainPassword(createCommand.PlainPassword)
+	if err != nil {
+		return err
+	}
+
+	user, err := as.factory.Create(userName, userMailAddress, userPlainPassword)
 	if err != nil {
 		return err
 	}

--- a/docker/mysql/db/init/001-ddl.sql
+++ b/docker/mysql/db/init/001-ddl.sql
@@ -4,9 +4,10 @@ USE `ddd_sample`;
 DROP TABLE IF EXISTS `users`;
 
 CREATE TABLE IF NOT EXISTS `users` (
-  `id`           CHAR(26)     NOT NULL COMMENT 'ユーザID',
-  `name`         VARCHAR(64)  NOT NULL COMMENT 'ユーザ名',
-  `mail_address` VARCHAR(255) NOT NULL COMMENT 'メールアドレス',
+  `id`              CHAR(26)     NOT NULL COMMENT 'ユーザID',
+  `name`            VARCHAR(64)  NOT NULL COMMENT 'ユーザ名',
+  `mail_address`    VARCHAR(255) NOT NULL COMMENT 'メールアドレス',
+  `hashed_password` VARCHAR(255) NOT NULL COMMENT 'パスワード',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_mail_address` (`mail_address`))
 ENGINE=InnoDB

--- a/domain/model/user/hashed_password.go
+++ b/domain/model/user/hashed_password.go
@@ -1,0 +1,24 @@
+package user
+
+import (
+	"errors"
+)
+
+// HashedPassword Value object express hashed user's passsword
+type HashedPassword []byte
+
+// NewHashedPassword Constructor generate user's HashedPassword value object
+func NewHashedPassword(arg []byte) (*HashedPassword, error) {
+
+	if arg == nil {
+		return nil, errors.New("UserHashedPassword is null")
+	}
+
+	hashedPassword := HashedPassword(arg)
+	return &hashedPassword, nil
+}
+
+// ToString Convert UserHashedPassword to String
+func (hashedPassword HashedPassword) ToString() string {
+	return string(hashedPassword)
+}

--- a/domain/model/user/plain_password.go
+++ b/domain/model/user/plain_password.go
@@ -1,0 +1,34 @@
+package user
+
+import (
+	"errors"
+	"regexp"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// PlainPassword Value object express user's PlainPassword
+type PlainPassword string
+
+// NOTE: define global because regexp's compile is slow.
+var passwordRegexp = regexp.MustCompile(`^[a-zA-Z_\d]{8,30}$`)
+
+// NewPlainPassword Constructor generate user's PlainPassword value object
+func NewPlainPassword(arg string) (*PlainPassword, error) {
+
+	if arg == "" {
+		return nil, errors.New("UserPlainPassword is null")
+	}
+
+	if !passwordRegexp.MatchString(arg) {
+		return nil, errors.New("UserPassword should consist of alphabet or half-size number or underscore, using more than 8 characters but less than 30")
+	}
+
+	plainPassword := PlainPassword(arg)
+	return &plainPassword, nil
+}
+
+// ToHash Convert plainPassword string to []byte
+func (plainPassword PlainPassword) ToHash() ([]byte, error) {
+	return bcrypt.GenerateFromPassword([]byte(plainPassword), bcrypt.DefaultCost)
+}

--- a/domain/model/user/plain_password.go
+++ b/domain/model/user/plain_password.go
@@ -28,6 +28,8 @@ func NewPlainPassword(arg string) (*PlainPassword, error) {
 	return &plainPassword, nil
 }
 
+// NOTE Domain layer shouldn't notice technical requirements?
+
 // ToHash Convert plainPassword string to []byte
 func (plainPassword PlainPassword) ToHash() ([]byte, error) {
 	return bcrypt.GenerateFromPassword([]byte(plainPassword), bcrypt.DefaultCost)

--- a/domain/model/user/user.go
+++ b/domain/model/user/user.go
@@ -6,13 +6,14 @@ import (
 
 // User Entity express user
 type User struct {
-	ID          ID
-	Name        Name
-	MailAddress MailAddress
+	ID             ID
+	Name           Name
+	MailAddress    MailAddress
+	HashedPassword HashedPassword
 }
 
 // NewUser Constructor generate user entity
-func NewUser(id *ID, name *Name, mailAddress *MailAddress) (*User, error) {
+func NewUser(id *ID, name *Name, mailAddress *MailAddress, hashedPassword *HashedPassword) (*User, error) {
 
 	if id == nil {
 		return nil, errors.New("UserID is null")
@@ -23,11 +24,15 @@ func NewUser(id *ID, name *Name, mailAddress *MailAddress) (*User, error) {
 	if mailAddress == nil {
 		return nil, errors.New("UserMailAddress is null")
 	}
+	if hashedPassword == nil {
+		return nil, errors.New("UserHashedPasseord is null")
+	}
 
 	user := new(User)
 	user.ID = *id
 	user.Name = *name
 	user.MailAddress = *mailAddress
+	user.HashedPassword = *hashedPassword
 
 	return user, nil
 }

--- a/infrastructure/mysql/user/dto.go
+++ b/infrastructure/mysql/user/dto.go
@@ -8,9 +8,10 @@ import (
 
 // User DTO about user entity
 type User struct {
-	ID          string `gorm:"primary_key"`
-	Name        string
-	MailAddress string
+	ID             string `gorm:"primary_key"`
+	Name           string
+	MailAddress    string
+	HashedPassword string
 }
 
 // ConvertDTO Convert Entity to DTO about User
@@ -18,11 +19,13 @@ func ConvertDTO(entityUser *domainModel.User) *User {
 	DTOUserID := entityUser.ID.ToString()
 	DTOUserName := entityUser.Name.ToString()
 	DTOUserMailAddress := entityUser.MailAddress.ToString()
+	DTOUserHashedPassword := entityUser.HashedPassword.ToString()
 
 	return &User{
-		ID:          DTOUserID,
-		Name:        DTOUserName,
-		MailAddress: DTOUserMailAddress,
+		ID:             DTOUserID,
+		Name:           DTOUserName,
+		MailAddress:    DTOUserMailAddress,
+		HashedPassword: DTOUserHashedPassword,
 	}
 }
 
@@ -48,5 +51,16 @@ func ConvertEntity(DTOUser *User) (*domainModel.User, error) {
 		return nil, err
 	}
 
-	return domainModel.NewUser(entityUserID, entityUserName, entityUserMailAddress)
+	// TODO Prevent from memory copy
+	entityUserHashedPassword, err := domainModel.NewHashedPassword([]byte(DTOUser.HashedPassword))
+	if err != nil {
+		return nil, err
+	}
+
+	return domainModel.NewUser(
+		entityUserID,
+		entityUserName,
+		entityUserMailAddress,
+		entityUserHashedPassword,
+	)
 }

--- a/interfaces/controller/user/index.go
+++ b/interfaces/controller/user/index.go
@@ -30,6 +30,7 @@ func (uc controller) Create(c echo.Context) error {
 		request struct {
 			Name        string `json:"name"`
 			MailAddress string `json:"mail_address"`
+			Password    string `json:"password"`
 		}
 		response struct {
 			AuthToken string `json:"auth_token"`
@@ -42,8 +43,9 @@ func (uc controller) Create(c echo.Context) error {
 	}
 
 	createCommand := applicationService.CreateCommand{
-		Name:        requestBody.Name,
-		MailAddress: requestBody.MailAddress,
+		Name:          requestBody.Name,
+		MailAddress:   requestBody.MailAddress,
+		PlainPassword: requestBody.Password,
 	}
 
 	if err := uc.applicationService.Register(createCommand); err != nil {


### PR DESCRIPTION
## About
ユーザ登録時にパスワードも登録する
## Details
- hash化前後のパスワードを値オブジェクト`plainPassword`と`hashedPassword`で表現
- `/resgister`で`passowrd`のjsonを受けとるように
- factoryでplainPassword->hashedPasswordを実装
- passwordは大文字小文字アルファベット+半角数字で8-30文字
- Userエンティティはハッシュ化されたパスワードのみを保持
## Remarks
- 値オブジェクト`plainPassword`に平文をハッシュ化させるメソッドを定義しているが、domain層に技術的な関心(暗号化など)が入るのはおかしいのではないか？
## Preview
<img width="1097" alt="スクリーンショット 2021-03-02 18 42 33" src="https://user-images.githubusercontent.com/38310693/109629331-1058f980-7b87-11eb-92ec-e6620c55a8b9.png">

<img width="201" alt="スクリーンショット 2021-03-02 18 44 50" src="https://user-images.githubusercontent.com/38310693/109629666-67f76500-7b87-11eb-8d5b-fb768901e1e1.png">
