### PR TITLE
feat: ユーザー作成時にJWTを生成・返却する

### DIFF
--- a/application/user/auth.go
+++ b/application/user/auth.go
@@ -1,0 +1,21 @@
+package user
+
+import (
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+
+	"github.com/karamaru-alpha/ddd-sample/constants"
+	domainModel "github.com/karamaru-alpha/ddd-sample/domain/model/user"
+)
+
+// GenerateJWT Generate JWT token
+func GenerateJWT(userID *domainModel.ID) (string, error) {
+	token := jwt.New(jwt.SigningMethodHS256)
+
+	claims := token.Claims.(jwt.MapClaims)
+	claims["userID"] = userID
+	claims["exp"] = time.Now().Add(time.Hour * 24).Unix()
+
+	return token.SignedString([]byte(constants.JWTSecretKey))
+}

--- a/constants/index.go
+++ b/constants/index.go
@@ -1,0 +1,4 @@
+package constants
+
+// JWTSecretKey Key gor JWT (usually hidden)
+var JWTSecretKey = "secret"

--- a/interfaces/controller/user/index.go
+++ b/interfaces/controller/user/index.go
@@ -48,12 +48,12 @@ func (uc controller) Create(c echo.Context) error {
 		PlainPassword: requestBody.Password,
 	}
 
-	if err := uc.applicationService.Register(createCommand); err != nil {
+	token, err := uc.applicationService.Register(createCommand)
+	if err != nil {
 		return err
 	}
 
-	// TODO implement JWT
 	return c.JSON(http.StatusCreated, &response{
-		AuthToken: "foo bar token",
+		AuthToken: token,
 	})
 }


### PR DESCRIPTION
## About
ユーザー作成時にJWTを生成・返却する
## Details
- JWT秘密鍵を`/constants/index.go`に保持（通常隠す）
- `/application/user/auth.go`にJWT生成処理を記述
- JWTにはuserIDとexp(有効期限)をセット
## Remarks
- JWT生成はapplicationServiceにおいたが正解か？
- TODO: ユーザ作成とトークン生成にTransactionをかける
## Preview
<img width="185" alt="スクリーンショット 2021-03-04 3 09 24" src="https://user-images.githubusercontent.com/38310693/109851442-07efe400-7c97-11eb-8618-0b531acfc26f.png">
